### PR TITLE
Bump Iris to 4.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ In the `examples` you will find our case studies:
 
 Cryptis is known to compile with the following dependencies:
 
-- rocq-prover v9.0.0 or v9.1.0
+- rocq-prover
+- rocq-core v9.1.1
 - rocq-mathcomp-ssreflect v2.5.0
 - coq-deriving v0.2.2
-- coq-iris v4.4.0
-- coq-iris-heap-lang v4.4.0
+- coq-iris v4.5.0
+- coq-iris-heap-lang v4.5.0
 
 ### Nix
 

--- a/cryptis/core/term/with_stdpp.v
+++ b/cryptis/core/term/with_stdpp.v
@@ -269,12 +269,12 @@ split.
   move=> t' t'' ts t'NX _ IH ?; rewrite subtermsE //.
   do 2![rewrite elem_of_union; right].
   rewrite elem_of_union_list; exists (subterms t''); split => //.
-  by rewrite elem_of_list_fmap; eauto.
+  by rewrite list_elem_of_fmap; eauto.
 - elim: t2; try by solve_subtermsP.
   move=> t IHt /is_trueP tNX ts IHts /is_trueP tsN0 _.
   rewrite subtermsE // !elem_of_union elem_of_union_list elem_of_singleton.
   case=> [-> | [/IHt ?|sub]]; eauto using subterm.
-  case: sub => _ [] /elem_of_list_fmap [] t' [] -> t'_ts sub.
+  case: sub => _ [] /list_elem_of_fmap [] t' [] -> t'_ts sub.
   suffices: subterm t1 t' by eauto using subterm.
   elim: {t IHt tNX tsN0} ts IHts t'_ts sub => /= [_|t ts IH [IHt IHts]].
     by rewrite elem_of_nil.
@@ -307,12 +307,12 @@ split.
   move=> t t' ts _ IH t'_ts.
   rewrite nonces_of_termE elem_of_union; right.
   rewrite elem_of_union_list; exists (nonces_of_term t'); split => //.
-  by rewrite elem_of_list_fmap; eauto.
+  by rewrite list_elem_of_fmap; eauto.
 - elim: t; try by solve_nonces_of_termP.
   move=> t IHt /is_trueP tNX ts IHts _ _.
   rewrite nonces_of_termE !elem_of_union elem_of_union_list.
   case=> [/IHt ?|sub]; eauto using subterm.
-  case: sub => _ [] /elem_of_list_fmap [] t' [] -> t'_ts sub.
+  case: sub => _ [] /list_elem_of_fmap [] t' [] -> t'_ts sub.
   suffices: subterm (TNonce a) t' by eauto using subterm.
   elim: {t tNX IHt} ts IHts t'_ts sub => /= [_|t ts IH [IHt IHts]].
     by rewrite elem_of_nil.
@@ -347,7 +347,7 @@ elim: t2 / => //.
   have ?: nonces_of_term t2' ⊆ ⋃ map nonces_of_term ts.
     move=> t t_t2'. rewrite elem_of_union_list.
     exists (nonces_of_term t2'). split => //.
-    rewrite elem_of_list_fmap. by eauto.
+    rewrite list_elem_of_fmap. by eauto.
   set_solver.
 Qed.
 

--- a/cryptis/core/term_meta.v
+++ b/cryptis/core/term_meta.v
@@ -99,7 +99,7 @@ iIntros "[_ name1] [_ name2]".
 iPoseProof (own_valid_2 with "name1 name2") as "%valid".
 rewrite -auth_frag_op auth_frag_valid in valid.
 move/(_ t): valid.
-rewrite lookup_op !lookup_singleton -Some_op Some_valid.
+rewrite lookup_op !lookup_singleton_eq -Some_op Some_valid.
 by move=> /to_agree_op_inv_L ->.
 Qed.
 

--- a/cryptis/lib.v
+++ b/cryptis/lib.v
@@ -96,7 +96,7 @@ iMod ("BC" with "HB"); eauto.
 Qed.
 
 Definition namespace_map_data {A : cmra} (N : namespace) (a : A) :=
-  reservation_map_data (positives_flatten N) a.
+  reservation_map_data (positives_flatten (namespace_car N)) a.
 
 Lemma namespace_map_alloc_update {A : cmra} E (N : namespace) (a : A) :
   ↑N ⊆ E →
@@ -104,7 +104,7 @@ Lemma namespace_map_alloc_update {A : cmra} E (N : namespace) (a : A) :
   reservation_map_token E ~~> namespace_map_data N a.
 Proof.
 move=> sub valid; apply: reservation_map_alloc => //.
-assert (H : positives_flatten N ∈ (↑N : coPset)).
+assert (H : positives_flatten (namespace_car N) ∈ (↑N : coPset)).
 { rewrite namespaces.nclose_unseal. apply elem_coPset_suffixes.
   exists 1%positive. by rewrite left_id_L. }
 set_solver.
@@ -115,7 +115,7 @@ Lemma reservation_map_disj {A : cmra} E x (a : A) :
   x ∉ E.
 Proof.
 rewrite reservation_map_valid_eq /= right_id_L left_id_L.
-by case=> _ /(_ x); rewrite lookup_singleton; case.
+by case=> _ /(_ x); rewrite lookup_singleton_eq; case.
 Qed.
 
 Lemma namespace_map_disj {A : cmra} E (N : namespace) (a : A) :
@@ -124,7 +124,7 @@ Lemma namespace_map_disj {A : cmra} E (N : namespace) (a : A) :
   False.
 Proof.
 move=> sub /reservation_map_disj.
-assert (H : positives_flatten N ∈ (↑N : coPset)).
+assert (H : positives_flatten (namespace_car N) ∈ (↑N : coPset)).
 { rewrite namespaces.nclose_unseal. apply elem_coPset_suffixes.
   exists 1%positive. by rewrite left_id_L. }
 set_solver.
@@ -183,10 +183,10 @@ apply: (anti_symm _).
 - iIntros "H %k %Y %X_k"; rewrite big_sepS_forall; iIntros "%x %x_Y".
   iApply "H"; iPureIntro.
   apply/elem_of_union_list; exists Y; split => //.
-  by rewrite elem_of_list_lookup; eauto.
+  by rewrite list_elem_of_lookup; eauto.
 - iIntros "H %x %x_X".
   case/elem_of_union_list: x_X => Y [Y_X x_Y].
-  case/elem_of_list_lookup: Y_X => k X_k.
+  case/list_elem_of_lookup: Y_X => k X_k.
   iSpecialize ("H" $! _ _ X_k).
   by rewrite big_sepS_forall; iApply "H".
 Qed.
@@ -216,7 +216,7 @@ have {}e: ∀ x' : K, x' ∈ dom m ↔ x' ∈ ({[x]} : gset K) by rewrite e.
 have: x ∈ ({[x]} : gset K) by rewrite elem_of_singleton.
 rewrite -e elem_of_dom; case=> y m_x; exists y.
 apply: map_eq=> x'; case: (decide (x' = x))=> [ {x'}->|ne].
-  by rewrite lookup_singleton.
+  by rewrite lookup_singleton_eq.
 rewrite lookup_singleton_ne // -(@not_elem_of_dom _ _ (gset K)).
 by rewrite e elem_of_singleton.
 Qed.
@@ -1179,7 +1179,7 @@ Lemma insert_same {A} (m1 m2 : gmap string A) (i : string) (x : A) :
 Proof.
 move=> e12; apply map_eq => j.
 destruct (decide (j = i)) as [->|ne].
-- by rewrite !lookup_insert.
+- by rewrite !lookup_insert_eq.
 - by rewrite !lookup_insert_ne // e12.
 Qed.
 
@@ -1194,7 +1194,7 @@ Qed.
 
 Lemma binder_insert_delete {A} (m : gmap string A) (i : binder) (x : A) :
   binder_insert i x (binder_delete i m) = binder_insert i x m.
-Proof. case: i => //= i; exact: insert_delete_insert. Qed.
+Proof. case: i => //= i; exact: insert_delete_eq. Qed.
 
 Lemma binder_insert_delete2 {A} (m : gmap string A) (i j : binder) (x y : A) :
   binder_insert i x (binder_insert j y (binder_delete i (binder_delete j m))) =
@@ -1202,17 +1202,17 @@ Lemma binder_insert_delete2 {A} (m : gmap string A) (i j : binder) (x y : A) :
 Proof.
 rewrite -(binder_insert_delete m j y).
 case: i j => [|i] [|j] //=.
-- by rewrite insert_delete_insert.
-- rewrite delete_commute !insert_delete_insert.
+- by rewrite insert_delete_eq.
+- rewrite delete_delete !insert_delete_eq.
   destruct (decide (i = j)) as [->|i_j].
-    by rewrite insert_delete_insert.
-  by rewrite insert_commute // insert_delete_insert insert_commute //.
+    by rewrite insert_delete_eq.
+  by rewrite insert_insert_ne // insert_delete_eq insert_insert_ne //.
 Qed.
 
 Lemma binder_delete_commute {A} (m : gmap string A) i j :
   binder_delete i (binder_delete j m) =
   binder_delete j (binder_delete i m).
-Proof. case: i j => [|i] [|j] //=; exact: delete_commute. Qed.
+Proof. case: i j => [|i] [|j] //=; exact: delete_delete. Qed.
 
 Definition nondet_nat_loop : val := rec: "loop" "n" :=
   if: nondet_bool #() then "n" else "loop" ("n" + #1).

--- a/cryptis/lib/gen_adequacy.v
+++ b/cryptis/lib/gen_adequacy.v
@@ -62,7 +62,7 @@ Theorem twp_rtc Σ Λ `{!invGpreS Σ} e σ P n :
        stateI σ n [] 0 ∗ WP e [{ v, ⌜ P v ⌝ }]) →
   ∃ v σ', rtc thread_step (e, σ) (of_val v, σ') ∧ P v.
 Proof.
-  intros Hwp. eapply pure_soundness.
+  intros Hwp. eapply (pure_soundness (PROP:=iPropI Σ)).
   apply (fupd_soundness_lc 0 ⊤ ⊤ _)=> Hinv. iIntros "_".
   iMod (Hwp) as (stateI num_laters_per_step fork_post stateI_mono) "[Hσ H]".
   set (iG := IrisG Hinv stateI fork_post num_laters_per_step stateI_mono).

--- a/cryptis/lib/session.v
+++ b/cryptis/lib/session.v
@@ -333,7 +333,7 @@ iMod (nown_update with "own") as "own".
   apply: op_local_update_frame.
   apply: (insert_local_update _ _ t).
   - by rewrite lookup_fmap SM_sA.
-  - by rewrite lookup_singleton.
+  - by rewrite lookup_singleton_eq.
   rewrite /session_status_both /session_status_auth /session_status_frag /=.
   rewrite -[● None as X in (_, X)]right_id.
   apply: auth_local_update.
@@ -342,7 +342,7 @@ iMod (nown_update with "own") as "own".
   - by [].
 rewrite auth_frag_op !nown_op.
 iDestruct "own" as "(own & sessA & sessB)".
-rewrite insert_singleton -singleton_op.
+rewrite insert_singleton_eq -singleton_op.
 rewrite auth_frag_op nown_op. iDestruct "sessA" as "[_ #sessA]".
 iFrame "res"; iModIntro; iSplitL; eauto; iModIntro.
 iClear "not_fresh".
@@ -358,7 +358,7 @@ iDestruct "inv" as "[inv_s inv]".
 iSplitL "inv_s"; first by iFrame.
 rewrite (big_sepM_delete _ (delete t SM)); last first.
   rewrite lookup_delete_ne; last eauto; eauto.
-iFrame; iSplitR "inv"; last by rewrite delete_commute.
+iFrame; iSplitR "inv"; last by rewrite delete_delete.
 iExists _, _, _; iSplit => //.
 by iRight; case: (rl); iSplit.
 Qed.

--- a/examples/alist/proofs.v
+++ b/examples/alist/proofs.v
@@ -64,7 +64,7 @@ case=> [kvs] [-> {v}] kvs_db. iIntros "%Φ _ Hpost".
 wp_lam. wp_pures. iApply (wp_cons _ (k, v')). iApply "Hpost".
 iPureIntro. exists ((k, v') :: kvs); split => //= k'.
 case: bool_decide_reflect => [<-|ne] //=;
-by rewrite (lookup_insert, lookup_insert_ne).
+by rewrite (lookup_insert_eq, lookup_insert_ne).
 Qed.
 
 Lemma wp_delete v db k E :
@@ -81,7 +81,7 @@ iApply (wp_filter_list (λ p : term * val, negb (bool_decide (k = p.1))))
   iApply wp_eq_term. wp_pures. by iApply "Hpost". }
 iIntros "!> _". iApply "Hpost". iPureIntro.
 eexists _; split; eauto => // k'. case: (decide (k = k')) => [<- {k'}|ne].
-- rewrite lookup_delete. case eq_find: List.find => [[t1 t2]|] //=.
+- rewrite lookup_delete_eq. case eq_find: List.find => [[t1 t2]|] //=.
   case/(@find_some _ _ _ _): eq_find => /= in_filter.
   case: bool_decide_reflect => // -> in in_filter *.
   rewrite filter_In /= in in_filter; case: in_filter => _.

--- a/examples/iso_dh/proofs/base.v
+++ b/examples/iso_dh/proofs/base.v
@@ -181,7 +181,7 @@ Lemma release_token_released_session si rl :
   False.
 Proof.
 iIntros "token [#init #resp]".
-iApply (term_meta_token with "token"); last by case: rl.
+iApply (term_meta_token (L:=bool) with "token"); last by case: rl.
 by [].
 Qed.
 
@@ -400,9 +400,10 @@ Lemma iso_dhGS_alloc `{!heapGS Σ, !cryptisGS Σ} E :
     iso_dh_ctx ∗ iso_dh_token ⊤ ∗
     seal_pred_token SIGN (E ∖ ↑iso_dhN).
 Proof.
-iIntros "% % token".
+iIntros "% %Hpre token".
 iMod gmeta_token_alloc as (γ_meta) "own".
-iExists (IsoDhGS _ γ_meta).
+set iso_dhGS0 := {| iso_dh_inG := Hpre; iso_dh_name := γ_meta |} : iso_dhGS Σ.
+iExists iso_dhGS0.
 iMod (iso_dh_ctx_alloc with "token") as "[#H ?]" => //.
 by iFrame.
 Qed.

--- a/examples/nsl_dh/proofs/base.v
+++ b/examples/nsl_dh/proofs/base.v
@@ -207,7 +207,7 @@ Lemma release_token_released_session si rl :
   False.
 Proof.
 iIntros "token [#init #resp]".
-iApply (term_meta_token with "token"); last by case: rl.
+iApply (term_meta_token (L:=bool) with "token"); last by case: rl.
 by [].
 Qed.
 
@@ -583,9 +583,10 @@ Lemma nsl_dhGS_alloc `{!heapGS Σ, !cryptisGS Σ} E :
     nsl_dh_ctx ∗ nsl_dh_token ⊤ ∗
     seal_pred_token AENC (E ∖ ↑nsl_dhN).
 Proof.
-iIntros "% % token".
+iIntros "% %Hpre token".
 iMod gmeta_token_alloc as (γ_meta) "own".
-iExists (NslDhGS _ γ_meta).
+set nsl_dhGS0 := {| nsl_dh_inG := Hpre; nsl_dh_name := γ_meta |} : nsl_dhGS Σ.
+iExists nsl_dhGS0.
 iMod (nsl_dh_ctx_alloc with "token") as "[#H ?]" => //.
 by iFrame.
 Qed.

--- a/examples/store/proofs/base.v
+++ b/examples/store/proofs/base.v
@@ -163,7 +163,7 @@ Proof.
 rewrite /public_db !big_sepM_forall.
 iIntros "#p_t1 #p_t2 #p_db %t1' %t2'".
 case: (decide (t1' = t1)) => [-> {t1'} | ne].
-- rewrite lookup_insert. iIntros "%e". case: e => ->. by eauto.
+- rewrite lookup_insert_eq. iIntros "%e". case: e => ->. by eauto.
 - by rewrite lookup_insert_ne //.
 Qed.
 

--- a/examples/store/proofs/db.v
+++ b/examples/store/proofs/db.v
@@ -70,7 +70,7 @@ move/(_ t): valid.
 rewrite !discrete_fun_lookup_op /to_db_state /db_singleton.
 case: (decide (t = t1)) => [-> {t}|t_t1]; last first.
 { rewrite lookup_insert_ne // !discrete_fun_lookup_singleton_ne //. }
-rewrite lookup_insert !discrete_fun_lookup_singleton //=.
+rewrite lookup_insert_eq !discrete_fun_lookup_singleton //=.
 move: (db' t1); apply/cmra_discrete_total_update.
 apply: auth_update.
 apply (transitivity (y := (None, None))).
@@ -89,7 +89,7 @@ case: (decide (t = t1)) => [-> {t}|t_t1]; last first.
 { rewrite lookup_insert_ne // !discrete_fun_lookup_singleton_ne //.
   rewrite decide_False //; set_solver. }
 rewrite decide_True // ?elem_of_singleton //.
-rewrite lookup_insert !discrete_fun_lookup_singleton //=.
+rewrite lookup_insert_eq !discrete_fun_lookup_singleton //=.
 move: (db' t1); apply/cmra_discrete_total_update.
 apply: auth_update.
 apply: option_local_update.

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1753121425,
-        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765887965,
-        "narHash": "sha256-JWHbipcA3vGwuMBy3TnCXOXjcwAhkO/x7OA3gDJ4euA=",
+        "lastModified": 1775581907,
+        "narHash": "sha256-aIBIBBLKFTG9rcdha98TLC5HiYjjOyBAPVl9JDiX3DM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c86ecd62d9ec163e4dc93e960ff7cd96f956ae9f",
+        "rev": "77bb0683a4d1cd66d08ccfe62a851e1068fbd23a",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {

--- a/rocq-cryptis.opam
+++ b/rocq-cryptis.opam
@@ -10,11 +10,12 @@ bug-reports: "https://github.com/arthuraa/cryptis/issues"
 dev-repo: "git+https://github.com/arthuraa/cryptis.git"
 
 depends: [
-  "rocq-prover" {= "9.1.0"}
+  "rocq-prover"
+  "rocq-core" {= "9.1.1"}
   "rocq-mathcomp-ssreflect" {= "2.5.0"}
   "coq-deriving" {= "0.2.2"}
-  "coq-iris" {= "4.4.0"}
-  "coq-iris-heap-lang" {= "4.4.0"}
+  "rocq-iris" {= "4.5.0"}
+  "rocq-iris-heap-lang" {= "4.5.0"}
 ]
 
 build: [make "-j%{jobs}%"]


### PR DESCRIPTION
Note:
1. This doesn't update the Nix flake.
2. The changes involve manually specifying implicit arguments/typeclass instances. I could not figure out if there was a way to do it without doing this.