### PR TITLE
CI: don't garbage-collect the Nix store before saving the cache.

### DIFF
--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           primary-key: nix-${{ matrix.system }}-${{ hashFiles('flake.lock') }}
           restore-prefixes-first-match: nix-${{ matrix.system }}-
-          gc-max-store-size-linux: 2000000000
-          gc-max-store-size-macos: 2000000000
           purge: true
           purge-created: 604800
           purge-primary-key: never


### PR DESCRIPTION
cache-nix-action runs `nix store gc --max <gc-max-store-size>` just before saving a new cache when that input is set. Drop the gc-max-store-size-{linux,macos} inputs (default is empty) so the whole store is cached as-is, with no garbage collection.